### PR TITLE
Improve site metadata for better bot indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains a simple static affiliate product catalog website.
 
-Open `index.html` to browse recommended products. Individual product pages contain affiliate links and structured data to help AI bots understand the content.
+Open `index.html` to browse recommended products. Individual product pages contain affiliate links and structured data to help search engines and chatbots understand the content. The home page now includes Open Graph metadata, a canonical link, and an ItemList JSON-LD block listing all products.
 
 Images are loaded from placeholder URLs so no binary assets are stored in the repository.
 

--- a/catalog.json
+++ b/catalog.json
@@ -5,5 +5,19 @@
     "affiliate_link": "https://example.com/affiliate/scaraway",
       "image": "https://via.placeholder.com/400?text=ScarAway+Gel",
     "tags": ["scar", "skincare", "gel"]
+  },
+  {
+    "name": "Amazing Gadget",
+    "description": "Innovative gadget with must-have features.",
+    "affiliate_link": "https://example.com/affiliate/gadget",
+    "image": "https://via.placeholder.com/400?text=Gadget",
+    "tags": ["gadget", "tech"]
+  },
+  {
+    "name": "Cool Widget",
+    "description": "Stylish widget that blends design and utility.",
+    "affiliate_link": "https://example.com/affiliate/widget",
+    "image": "https://via.placeholder.com/400?text=Widget",
+    "tags": ["widget", "tool"]
   }
 ]

--- a/index.html
+++ b/index.html
@@ -5,6 +5,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Top Recommended Products</title>
   <meta name="description" content="Discover our top recommended products with direct affiliate links.">
+  <link rel="canonical" href="https://example.com/">
+  <meta property="og:title" content="Top Recommended Products">
+  <meta property="og:description" content="Discover our top recommended products with direct affiliate links.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://example.com/">
+  <meta property="og:image" content="https://via.placeholder.com/1200x630?text=Catalog">
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -19,5 +25,28 @@
       <div class="product-item"><a href="products/product3.html">Cool Widget</a></div>
     </div>
   </main>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "url": "https://example.com/products/scaraway-scar-gel.html"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "url": "https://example.com/products/product2.html"
+      },
+      {
+        "@type": "ListItem",
+        "position": 3,
+        "url": "https://example.com/products/product3.html"
+      }
+    ]
+  }
+  </script>
 </body>
 </html>

--- a/products/product2.html
+++ b/products/product2.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Amazing Gadget</title>
+  <meta name="description" content="Amazing Gadget is a must-have tool for tech enthusiasts.">
+  <link rel="stylesheet" href="../style.css">
+  <meta property="og:title" content="Amazing Gadget">
+  <meta property="og:description" content="Check out the features of Amazing Gadget.">
+  <meta property="og:image" content="https://via.placeholder.com/400?text=Gadget">
+  <meta property="og:type" content="product">
+</head>
+<body>
+  <header>
+    <h1>Amazing Gadget</h1>
+  </header>
+  <main>
+    <p>Amazing Gadget offers innovative functions that make your life easier.</p>
+    <img src="https://via.placeholder.com/400?text=Gadget" alt="Amazing Gadget" style="max-width:100%; height:auto;">
+    <p><a href="https://example.com/affiliate/gadget" class="buy">Buy Now</a></p>
+  </main>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org/",
+    "@type": "Product",
+    "name": "Amazing Gadget",
+    "image": "https://via.placeholder.com/400?text=Gadget",
+    "description": "Amazing Gadget is a must-have tool for tech enthusiasts.",
+    "offers": {
+      "@type": "Offer",
+      "url": "https://example.com/affiliate/gadget",
+      "priceCurrency": "USD",
+      "price": "29.99",
+      "availability": "https://schema.org/InStock"
+    }
+  }
+  </script>
+</body>
+</html>

--- a/products/product3.html
+++ b/products/product3.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cool Widget</title>
+  <meta name="description" content="Cool Widget brings style and function together.">
+  <link rel="stylesheet" href="../style.css">
+  <meta property="og:title" content="Cool Widget">
+  <meta property="og:description" content="Discover why Cool Widget is a popular choice.">
+  <meta property="og:image" content="https://via.placeholder.com/400?text=Widget">
+  <meta property="og:type" content="product">
+</head>
+<body>
+  <header>
+    <h1>Cool Widget</h1>
+  </header>
+  <main>
+    <p>Cool Widget provides the perfect balance of utility and design.</p>
+    <img src="https://via.placeholder.com/400?text=Widget" alt="Cool Widget" style="max-width:100%; height:auto;">
+    <p><a href="https://example.com/affiliate/widget" class="buy">Buy Now</a></p>
+  </main>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org/",
+    "@type": "Product",
+    "name": "Cool Widget",
+    "image": "https://via.placeholder.com/400?text=Widget",
+    "description": "Cool Widget brings style and function together.",
+    "offers": {
+      "@type": "Offer",
+      "url": "https://example.com/affiliate/widget",
+      "priceCurrency": "USD",
+      "price": "24.99",
+      "availability": "https://schema.org/InStock"
+    }
+  }
+  </script>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -6,4 +6,10 @@
   <url>
     <loc>https://example.com/products/scaraway-scar-gel.html</loc>
   </url>
+  <url>
+    <loc>https://example.com/products/product2.html</loc>
+  </url>
+  <url>
+    <loc>https://example.com/products/product3.html</loc>
+  </url>
 </urlset>


### PR DESCRIPTION
## Summary
- add canonical link and Open Graph meta tags
- expose ItemList JSON-LD on home page
- add product pages for Amazing Gadget and Cool Widget
- expand catalog data and sitemap
- clarify README with metadata details

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686ebb08f310833187fb3cf1f9ebd9c6