### PR TITLE
Add page visit tracker

### DIFF
--- a/compare/scar-gels.html
+++ b/compare/scar-gels.html
@@ -43,6 +43,8 @@
   </main>
   <footer>
     <p>&copy; 2024 Example.com</p>
+    <p id="visit-count"></p>
   </footer>
+  <script src="../tracking.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -44,6 +44,7 @@
   </main>
   <footer>
     <p>&copy; 2024 Example.com</p>
+    <p id="visit-count"></p>
   </footer>
   <script type="application/ld+json">
   {
@@ -56,5 +57,6 @@
     ]
   }
   </script>
+  <script src="tracking.js"></script>
 </body>
 </html>

--- a/products/product2.html
+++ b/products/product2.html
@@ -26,6 +26,7 @@
 
   <footer>
     <p>&copy; 2024 Example.com</p>
+    <p id="visit-count"></p>
   </footer>
 
   <script type="application/ld+json">
@@ -44,5 +45,6 @@
     }
   }
   </script>
+  <script src="../tracking.js"></script>
 </body>
 </html>

--- a/products/product3.html
+++ b/products/product3.html
@@ -26,6 +26,7 @@
 
   <footer>
     <p>&copy; 2024 Example.com</p>
+    <p id="visit-count"></p>
   </footer>
 
   <script type="application/ld+json">
@@ -44,5 +45,6 @@
     }
   }
   </script>
+  <script src="../tracking.js"></script>
 </body>
 </html>

--- a/products/scaraway-gel.html
+++ b/products/scaraway-gel.html
@@ -21,6 +21,10 @@
       Category: skincare
     </div>
   </main>
+  <footer>
+    <p>&copy; 2024 Example.com</p>
+    <p id="visit-count"></p>
+  </footer>
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -38,5 +42,6 @@
     }
   }
   </script>
+  <script src="../tracking.js"></script>
 </body>
 </html>

--- a/tracking.js
+++ b/tracking.js
@@ -1,0 +1,11 @@
+(function() {
+  const key = 'visits-' + window.location.pathname;
+  const count = Number(localStorage.getItem(key) || 0) + 1;
+  localStorage.setItem(key, count);
+  document.addEventListener('DOMContentLoaded', function() {
+    const el = document.getElementById('visit-count');
+    if (el) {
+      el.textContent = 'Visits: ' + count;
+    }
+  });
+})();


### PR DESCRIPTION
## Summary
- add tracking.js to store visit count per page in `localStorage`
- display local visit counts on each page using the new script

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686ed6f4313883319e81569119f5f3c4